### PR TITLE
Added use of PolymerModelData to Load textures

### DIFF
--- a/src/main/java/pw/smto/moretools/ExcavatorToolItem.java
+++ b/src/main/java/pw/smto/moretools/ExcavatorToolItem.java
@@ -1,6 +1,7 @@
 package pw.smto.moretools;
 
 import eu.pb4.polymer.core.api.item.PolymerItem;
+import eu.pb4.polymer.resourcepack.api.PolymerModelData;
 import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.component.DataComponentTypes;
@@ -26,6 +27,7 @@ public class ExcavatorToolItem extends MiningToolItem implements PolymerItem, Mo
     private final ShovelItem base;
     private final float baseSpeed;
     private boolean actAsShovel = false;
+    private final PolymerModelData model;
 
     public ExcavatorToolItem(ShovelItem base) {
         super(base.getMaterial(), BlockTags.SHOVEL_MINEABLE, new Item.Settings().attributeModifiers(
@@ -37,6 +39,9 @@ public class ExcavatorToolItem extends MiningToolItem implements PolymerItem, Mo
         );
         this.base = base;
         this.baseSpeed = base.getMaterial().getMiningSpeedMultiplier();
+        this.model = PolymerResourcePackUtils.requestModel(base, Identifier.of(MoreTools.MOD_ID,
+                "item/" + Registries.ITEM.getId(this.base).getPath().replace("shovel", "excavator")));
+
     }
 
 
@@ -63,12 +68,12 @@ public class ExcavatorToolItem extends MiningToolItem implements PolymerItem, Mo
 
     @Override
     public Item getPolymerItem(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return this.base;
+        return this.model.item();
     }
 
     @Override
     public int getPolymerCustomModelData(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return PolymerResourcePackUtils.requestModel(this.base, Identifier.of(MoreTools.MOD_ID, "item/" + Registries.ITEM.getId(this.base).getPath().replace("shovel", "excavator"))).value();
+        return this.model.value();
     }
 
     @Override

--- a/src/main/java/pw/smto/moretools/HammerToolItem.java
+++ b/src/main/java/pw/smto/moretools/HammerToolItem.java
@@ -1,6 +1,7 @@
 package pw.smto.moretools;
 
 import eu.pb4.polymer.core.api.item.PolymerItem;
+import eu.pb4.polymer.resourcepack.api.PolymerModelData;
 import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.component.DataComponentTypes;
@@ -26,6 +27,8 @@ public class HammerToolItem extends MiningToolItem implements PolymerItem, MoreT
     private final float baseSpeed;
     private boolean actAsPickaxe = false;
 
+    private final PolymerModelData model;
+
     public HammerToolItem(PickaxeItem base) {
         super(base.getMaterial(), BlockTags.PICKAXE_MINEABLE, new Item.Settings().attributeModifiers(
                 MiningToolItem.createAttributeModifiers(
@@ -36,6 +39,8 @@ public class HammerToolItem extends MiningToolItem implements PolymerItem, MoreT
         ));
         this.base = base;
         this.baseSpeed = base.getMaterial().getMiningSpeedMultiplier();
+        this.model = PolymerResourcePackUtils.requestModel(base, Identifier.of(MoreTools.MOD_ID,
+                "item/" + Registries.ITEM.getId(this.base).getPath().replace("pickaxe", "hammer")));
     }
 
     @Override
@@ -102,12 +107,12 @@ public class HammerToolItem extends MiningToolItem implements PolymerItem, MoreT
 
     @Override
     public Item getPolymerItem(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return this.base;
+        return this.model.item();
     }
 
     @Override
     public int getPolymerCustomModelData(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return PolymerResourcePackUtils.requestModel(this.base, Identifier.of(MoreTools.MOD_ID, "item/" + Registries.ITEM.getId(this.base).getPath().replace("pickaxe", "hammer"))).value();
+        return this.model.value();
     }
     @Override
     public Text getName(ItemStack stack) {

--- a/src/main/java/pw/smto/moretools/SawToolItem.java
+++ b/src/main/java/pw/smto/moretools/SawToolItem.java
@@ -1,6 +1,7 @@
 package pw.smto.moretools;
 
 import eu.pb4.polymer.core.api.item.PolymerItem;
+import eu.pb4.polymer.resourcepack.api.PolymerModelData;
 import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -33,6 +34,7 @@ public class SawToolItem extends MiningToolItem implements PolymerItem, MoreTool
     private final AxeItem base;
     private final float baseSpeed;
     private boolean actAsAxe = false;
+    private final PolymerModelData model;
 
     public SawToolItem(AxeItem base) {
         super(base.getMaterial(), BlockTags.AXE_MINEABLE, new Settings().attributeModifiers(
@@ -44,6 +46,10 @@ public class SawToolItem extends MiningToolItem implements PolymerItem, MoreTool
         );
         this.base = base;
         this.baseSpeed = base.getMaterial().getMiningSpeedMultiplier();
+
+        this.model = PolymerResourcePackUtils.requestModel(base, Identifier.of(MoreTools.MOD_ID,
+                "item/" + Registries.ITEM.getId(this.base).getPath().replace("axe", "saw")));
+
     }
 
 
@@ -70,12 +76,12 @@ public class SawToolItem extends MiningToolItem implements PolymerItem, MoreTool
 
     @Override
     public Item getPolymerItem(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return this.base;
+        return this.model.item();
     }
 
     @Override
     public int getPolymerCustomModelData(ItemStack itemStack, @Nullable ServerPlayerEntity player) {
-        return PolymerResourcePackUtils.requestModel(this.base, Identifier.of(MoreTools.MOD_ID, "item/" + Registries.ITEM.getId(this.base).getPath().replace("axe", "saw"))).value();
+        return this.model.value();
     }
 
     @Override


### PR DESCRIPTION
Hi!

Wanted to help out and saw that the texture deployment could be improved so it uses polymers resource pack generation better. Now servers with polymer's auto host running will find that these textures are now included on startup without needing to run the /polymer generate-pack command. This should mean users don't need to mess around with setting up the resource-pack in their server.properties file. 

apologies if this is too forward.